### PR TITLE
Fix dataset balancing by using numpy's uniform random sampling

### DIFF
--- a/csc2034-ds-demos-master/helpers.py
+++ b/csc2034-ds-demos-master/helpers.py
@@ -288,7 +288,7 @@ def downsample(X,CL):
     X_reb = np.arange(0).reshape(0, X.shape[1])
     CL_reb = np.arange(0)
     for i in range(len(CL)):
-        if CL[i] == majority and randn() <= threshold:
+        if CL[i] == majority and np.random.random() <= threshold:
             ## removing record
             n +=1
         else:


### PR DESCRIPTION
Changed the usage of rand() to np.random.random() to ensure the generation of numbers is uniformly distributed between 0 and 1 rather than across a normal distribution.

This modification guarantees that the dataset's downsampling process precisely reduces the majority class instances to achieve a balanced dataset effectively.